### PR TITLE
Update socket.io client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",
   "repository": {
@@ -22,7 +22,7 @@
     "assert": "^2.0.0",
     "mediasoup-client": "^3.6.82",
     "sdp": "^3.1.0",
-    "socket.io-client": "1.7.4",
+    "socket.io-client": "^4.6.1",
     "uuid": "^9.0.0",
     "webrtc-adapter": "^8.2.0"
   },

--- a/src/utils/ServerSocket.js
+++ b/src/utils/ServerSocket.js
@@ -15,10 +15,10 @@ export default class ServerSocket {
         }
 
         this._socket = io(hostName, options);
-        this._socket.on("reconnect", () => {
+        this._socket.io.on("reconnect", () => {
             this._socket.sendBuffer = [];
         });
-        this._socket.on("reconnect_attempt", () => {
+        this._socket.io.on("reconnect_attempt", () => {
             if (this._wasConnectedUsingWebsocket) {
                 this._socket.io.opts.transports = ["websocket"];
                 // only fallback to polling if not safari
@@ -74,6 +74,10 @@ export default class ServerSocket {
             this._socket.io.engine.transport &&
             this._socket.io.engine.transport.name
         );
+    }
+
+    getManager() {
+        return this._socket.io;
     }
 
     isConnecting() {


### PR DESCRIPTION
Update to the latest supported socket.io client. This is the same changes as we did in our internal repo, only leaving out the legacy ServerSocket as we dont need that here.