### PR TITLE
fromLocation function return api and signal urls

### DIFF
--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -20,6 +20,8 @@ export function fromLocation({ host = "whereby.com", protocol = "https:" } = {})
     let subdomain = "";
     let domain = host;
     let subdomainSeparator = ".";
+    let api = "https://api.whereby.dev";
+    let signal = "wss://signal.appearin.net";
     for (const { separator, pattern } of subdomainPatterns) {
         const match = pattern.exec(host);
         if (match) {
@@ -30,8 +32,16 @@ export function fromLocation({ host = "whereby.com", protocol = "https:" } = {})
         }
     }
     const organizationDomain = !subdomain ? domain : `${subdomain}${subdomainSeparator}${domain}`;
+    const match = localstackPattern.exec(host)
+    if (match) {
+        const domainWithoutPort = domain.substring(0, domain.indexOf(":"));
+        api = `https://${domainWithoutPort}:4090`;
+        signal = `wss://${domainWithoutPort}:4070`;
+    }
 
     return {
+        api,
+        signal,
         domain,
         domainWithSeparator: `${subdomainSeparator}${domain}`,
         organizationDomain,


### PR DESCRIPTION
add API and Signal urls to fromLocation function.

When running `broswer-sdk` on `local-stack` it uses production API and Signal. It is impossible to make it use local-stack's API and Signal, without changing code https://github.com/whereby/browser-sdk/blob/0b9c5bbef6122ae88674f9cd49d9026da656cd4e/src/lib/RoomConnection.ts#L115


I've introduced these vars here, so that `broswe-sdk` could use them and when working on local-stack it will automatically use local API and Signal servers.
