### PR TITLE
Add missing events dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "assert": "^2.0.0",
+    "events": "^3.3.0",
     "mediasoup-client": "^3.6.80",
     "rtcstats": "github:lifeonairteam/rtcstats#v3.1.0",
     "sdp": "^2.2.0",


### PR DESCRIPTION
We use the `events` pkg in the BandwidthTester and VegaConnection libs, but this dep was not installed directly. It worked as it was installed already because of another package. It's safer to have it in this repo's package.json, so this PR adds it there as a dependency.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.4--canary.11.6326145620.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.0.4--canary.11.6326145620.0
  # or 
  yarn add @whereby/jslib-media@1.0.4--canary.11.6326145620.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
