### PR TITLE
Add audio redundancy RED RFC2198 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/P2pRtcManager.js
+++ b/src/webrtc/P2pRtcManager.js
@@ -46,8 +46,28 @@ export default class P2pRtcManager extends BaseRtcManager {
         }
     }
 
-    _setCodecPreferences(pc, vp9On, av1On) {
+    _setCodecPreferences(pc, vp9On, av1On, redOn) {
         try {
+            // audio
+            const audioTransceivers = pc
+                .getTransceivers()
+                .filter(transceiver => transceiver?.sender?.track?.kind === "audio");
+
+            audioTransceivers.forEach(audioTransceiver => {
+                // If not implemented return
+                if (typeof RTCRtpSender.getCapabilities === undefined) return;
+                const capabilities = RTCRtpSender.getCapabilities("audio");
+                for (let i = 0; i < capabilities.codecs.length; i++) {
+                    if (redOn && capabilities.codecs[i].mimeType.toLowerCase() === "audio/red") {
+                        capabilities.codecs.unshift(capabilities.codecs.splice(i, 1)[0]);
+                        break;
+                    }
+                }
+                // If not implemented return
+                if (typeof audioTransceiver.setCodecPreferences === undefined) return;
+                audioTransceiver.setCodecPreferences(capabilities.codecs);
+            });
+            // video
             const videoTransceivers = pc
                 .getTransceivers()
                 .filter((transceiver) => transceiver?.sender?.track?.kind === "video");
@@ -89,19 +109,19 @@ export default class P2pRtcManager extends BaseRtcManager {
         }
         session.isOperationPending = true;
 
-        const { vp9On, av1On } = this._features;
+        const { vp9On, av1On, redOn } = this._features;
 
         // Set codec preferences to video transceivers
-        if (vp9On || av1On) {
-            this._setCodecPreferences(pc, vp9On, av1On);
+        if (vp9On || av1On || redOn) {
+            this._setCodecPreferences(pc, vp9On, av1On, redOn);
         }
 
         pc.createOffer(constraints || this.offerOptions)
             .then((offer) => {
                 // SDP munging workaround for Firefox, because it doesn't support setCodecPreferences()
                 // Only vp9 because FF does not support AV1 yet
-                if (vp9On && browserName === "firefox") {
-                    offer.sdp = setCodecPreferenceSDP(offer.sdp, vp9On);
+                if (vp9On || redOn && browserName === "firefox") {
+                    offer.sdp = setCodecPreferenceSDP(offer.sdp, vp9On, redOn);
                 }
 
                 this._emitServerEvent(RELAY_MESSAGES.SDP_OFFER, {

--- a/src/webrtc/P2pRtcManager.js
+++ b/src/webrtc/P2pRtcManager.js
@@ -51,11 +51,11 @@ export default class P2pRtcManager extends BaseRtcManager {
             // audio
             const audioTransceivers = pc
                 .getTransceivers()
-                .filter(transceiver => transceiver?.sender?.track?.kind === "audio");
+                .filter((transceiver) => transceiver?.sender?.track?.kind === "audio");
 
-            audioTransceivers.forEach(audioTransceiver => {
+            audioTransceivers.forEach((audioTransceiver) => {
                 // If not implemented return
-                if (typeof RTCRtpSender.getCapabilities === undefined) return;
+                if (typeof RTCRtpSender.getCapabilities === "undefined") return;
                 const capabilities = RTCRtpSender.getCapabilities("audio");
                 for (let i = 0; i < capabilities.codecs.length; i++) {
                     if (redOn && capabilities.codecs[i].mimeType.toLowerCase() === "audio/red") {
@@ -64,7 +64,7 @@ export default class P2pRtcManager extends BaseRtcManager {
                     }
                 }
                 // If not implemented return
-                if (typeof audioTransceiver.setCodecPreferences === undefined) return;
+                if (typeof audioTransceiver.setCodecPreferences === "undefined") return;
                 audioTransceiver.setCodecPreferences(capabilities.codecs);
             });
             // video
@@ -120,7 +120,7 @@ export default class P2pRtcManager extends BaseRtcManager {
             .then((offer) => {
                 // SDP munging workaround for Firefox, because it doesn't support setCodecPreferences()
                 // Only vp9 because FF does not support AV1 yet
-                if (vp9On || redOn && browserName === "firefox") {
+                if ((vp9On || redOn) && browserName === "firefox") {
                     offer.sdp = setCodecPreferenceSDP(offer.sdp, vp9On, redOn);
                 }
 

--- a/src/webrtc/Session.js
+++ b/src/webrtc/Session.js
@@ -214,7 +214,6 @@ export default class Session {
         try {
             // do not handle state change events when we close the connection explicitly
             pc.close();
-            this.pc = null;
         } catch (e) {
             console.warn("failures during close of session", e);
             // we're not interested in errors from RTCPeerConnection.close()

--- a/src/webrtc/Session.js
+++ b/src/webrtc/Session.js
@@ -214,6 +214,7 @@ export default class Session {
         try {
             // do not handle state change events when we close the connection explicitly
             pc.close();
+            this.pc = null;
         } catch (e) {
             console.warn("failures during close of session", e);
             // we're not interested in errors from RTCPeerConnection.close()

--- a/src/webrtc/sdpModifier.js
+++ b/src/webrtc/sdpModifier.js
@@ -5,10 +5,26 @@ import * as sdpTransform from "sdp-transform";
 const browserName = adapter.browserDetails.browser;
 const browserVersion = adapter.browserDetails.version;
 
-export function setCodecPreferenceSDP(sdp, vp9On) {
+export function setCodecPreferenceSDP(sdp, vp9On, redOn) {
     try {
         const sdpObject = sdpTransform.parse(sdp);
         if (Array.isArray(sdpObject?.media)) {
+            //audio
+            const mediaAudio = sdpObject.media.find((m) => m.type === "audio");
+            if (Array.isArray(mediaAudio?.rtp)) {
+                const rtp = mediaAudio.rtp;
+                for (let i = 0; i < rtp.length; i++) {
+                    if (redOn && rtp[i].codec === "red") {
+                        const payloads = mediaAudio.payloads.split(" ");
+                        const pt = payloads.indexOf("" + rtp[i].payload);
+                        if (pt && pt !== -1 && pt >= 0) {
+                            payloads.unshift(payloads.splice(pt, 1)[0]);
+                            mediaAudio.payloads = payloads.join(" ");
+                        }
+                    }
+                }
+            }
+            //video
             const mediaVideo = sdpObject.media.find((m) => m.type === "video");
             if (Array.isArray(mediaVideo?.rtp)) {
                 const rtp = mediaVideo.rtp;


### PR DESCRIPTION
- Add flag for RED RFC2198 codec preference change support
- Set pc null to make sure pc is released after it is closed.
- Bump version

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.5--canary.14.6429718182.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.0.5--canary.14.6429718182.0
  # or 
  yarn add @whereby/jslib-media@1.0.5--canary.14.6429718182.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
