### PR TITLE
Add jitter buffer delay target for all incoming RTCRtpReceiver objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,8 +1,0 @@
-/* globals process */
-
-const AWF_BASE_URL = process.env.AWF_BASE_URL;
-const AWF_API_BASE_URL = process.env.AWF_API_BASE_URL;
-const AP_ROOM_BASE_URL = process.env.AP_ROOM_BASE_URL;
-const CAMERA_STREAM_ID = "0";
-
-export { AWF_BASE_URL, AWF_API_BASE_URL, AP_ROOM_BASE_URL, CAMERA_STREAM_ID };

--- a/src/utils/turnConstants.js
+++ b/src/utils/turnConstants.js
@@ -1,2 +1,0 @@
-export const MAXIMUM_TURN_BANDWIDTH = 512; // kbps;
-export const MAXIMUM_TURN_BANDWIDTH_PREMIUM = 768; // kbps;

--- a/src/webrtc/BaseRtcManager.js
+++ b/src/webrtc/BaseRtcManager.js
@@ -8,7 +8,7 @@ import rtcManagerEvents from "./rtcManagerEvents";
 import Session from "./Session";
 import assert from "assert";
 import rtcStats from "./rtcStatsService";
-import { MAXIMUM_TURN_BANDWIDTH, MAXIMUM_TURN_BANDWIDTH_UNLIMITED } from "./turnConstants";
+import { MAXIMUM_TURN_BANDWIDTH, MAXIMUM_TURN_BANDWIDTH_UNLIMITED, MEDIA_JITTER_BUFFER_TARGET } from "./constants";
 import adapter from "webrtc-adapter";
 
 const CAMERA_STREAM_ID = RtcStream.getCameraId();
@@ -107,6 +107,20 @@ export default class BaseRtcManager {
                 previous: previousStatus,
             });
         }, 0);
+    }
+
+    _setJitterBufferTarget(pc) {
+        try {
+            const receivers = pc.getReceivers();
+
+            receivers.forEach((receiver) => {
+                receiver.jitterBufferTarget = MEDIA_JITTER_BUFFER_TARGET;
+                // Legacy Chrome API
+                receiver.playoutDelayHint = MEDIA_JITTER_BUFFER_TARGET / 1000; // seconds
+            });
+        } catch (error) {
+            logger.error("Error during setting jitter buffer target:", error);
+        }
     }
 
     _emitServerEvent(eventName, data, callback) {

--- a/src/webrtc/P2pRtcManager.js
+++ b/src/webrtc/P2pRtcManager.js
@@ -9,6 +9,7 @@ import adapter from "webrtc-adapter";
 const logger = console;
 const CAMERA_STREAM_ID = RtcStream.getCameraId();
 const browserName = adapter.browserDetails.browser;
+
 export default class P2pRtcManager extends BaseRtcManager {
     _connect(clientId) {
         this.rtcStatsReconnect();
@@ -226,6 +227,10 @@ export default class P2pRtcManager extends BaseRtcManager {
             isOfferer,
         });
         const pc = session.pc;
+
+        if (this._features.increaseIncomingMediaBufferOn) {
+            this._setJitterBufferTarget(pc);
+        }
 
         /*
          * Explicitly add the video track so that stopOrResumeVideo() can

--- a/src/webrtc/Session.js
+++ b/src/webrtc/Session.js
@@ -2,7 +2,7 @@ import * as sdpModifier from "./sdpModifier";
 import * as statsHelper from "./statsHelper";
 import { setVideoBandwidthUsingSetParameters } from "./rtcrtpsenderHelper";
 import adapter from "webrtc-adapter";
-import { MAXIMUM_TURN_BANDWIDTH_UNLIMITED } from "./turnConstants";
+import { MAXIMUM_TURN_BANDWIDTH_UNLIMITED } from "./constants";
 
 const logger = console;
 

--- a/src/webrtc/VegaRtcManager.js
+++ b/src/webrtc/VegaRtcManager.js
@@ -9,6 +9,7 @@ import rtcStats from "./rtcStatsService";
 import adapter from "webrtc-adapter";
 import VegaConnection from "./VegaConnection";
 import { getMediaSettings, modifyMediaCapabilities } from "../utils/mediaSettings";
+import { MEDIA_JITTER_BUFFER_TARGET } from "./constants";
 import { getHandler } from "../utils/getHandler";
 import { v4 as uuidv4 } from "uuid";
 import createMicAnalyser from "./VegaMicAnalyser";
@@ -1351,6 +1352,16 @@ export default class VegaRtcManager {
 
             this._consumerClosedCleanup(consumer);
         });
+
+        if (this._features.increaseIncomingMediaBufferOn && consumer.rtpReceiver) {
+            try {
+                consumer.rtpReceiver.jitterBufferTarget = MEDIA_JITTER_BUFFER_TARGET;
+                // Legacy Chrome API
+                consumer.rtpReceiver.playoutDelayHint = MEDIA_JITTER_BUFFER_TARGET / 1000; // seconds
+            } catch (error) {
+                logger.error("Error during setting jitter buffer target:", error);
+            }
+        }
 
         const { sourceClientId: clientId, screenShare, streamId } = consumer.appData;
         const clientState = this._getOrCreateClientState(clientId);

--- a/src/webrtc/constants.js
+++ b/src/webrtc/constants.js
@@ -1,2 +1,4 @@
 export const MAXIMUM_TURN_BANDWIDTH = 1280; // kbps;
 export const MAXIMUM_TURN_BANDWIDTH_UNLIMITED = -1; // kbps;
+
+export const MEDIA_JITTER_BUFFER_TARGET = 400; // milliseconds;


### PR DESCRIPTION
Add a jitter buffer delay target of 400 milliseconds for all incoming P2P/SFU audio/video tracks in all RTCRtpReceiver objects.

This feature can be enabled by passing `increaseIncomingMediaBuffer: true` in to `RtcManagerDispatcher` constructor (or directly to `P2pRtcManager` and `VegaRtcManager` constructors). In `pwa` this is handled automatically by adding `?increaseIncomingMediaBuffer` to a room URL and/or by switching on the `increaseIncomingMediaBuffer` feature flag.

---

Prior to this experiement, TestDevLab ran some performance testing and benchmarking against Google Meet.

The charts below show a number of quality metrics over time as packet loss is slowly increased from 0% to 20% and back to 0%. Notice how our delay is non-linear compared to the competitors result:

<img width="631" alt="Screenshot 2023-10-10 at 14 12 36" src="https://github.com/whereby/pwa/assets/119658286/68771f48-4b4c-42f9-9581-73b8b4d4049e">

<img width="531" alt="Screenshot 2023-10-10 at 14 16 03" src="https://github.com/whereby/pwa/assets/119658286/b6107153-4785-45a8-90a5-d7162c2b829c">

<img width="522" alt="Screenshot 2023-10-10 at 14 16 21" src="https://github.com/whereby/pwa/assets/119658286/00b6c797-98a0-49c8-a9e8-344d52b9e901">


[Source (internal use only)](https://docs.google.com/presentation/d/1tCpDgAcFxmKRbUSbcBD2GUT_NYJD1K-UnFmobbW9OEs/edit#slide=id.g284838d3d0c_0_55)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.1--canary.17.6479570171.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.1.1--canary.17.6479570171.0
  # or 
  yarn add @whereby/jslib-media@1.1.1--canary.17.6479570171.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
