### PR TITLE
Update socket.io-client to latest (minor) version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rtcstats": "github:lifeonairteam/rtcstats#v3.1.0",
     "sdp": "^2.2.0",
     "sdp-transform": "^2.14.1",
-    "socket.io-client": "^4.6.1",
+    "socket.io-client": "4.7.2",
     "socket.io-client-legacy": "npm:socket.io-client@1.7.4",
     "uuid": "^9.0.1",
     "webrtc-adapter": "^7.3.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",


### PR DESCRIPTION
Update `socket.io-client` library dependency from `^4.6.1` to `4.7.2` (removing `^` to force version to be same as that used in our Signal Server).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.1--canary.19.6544149237.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.2.1--canary.19.6544149237.0
  # or 
  yarn add @whereby/jslib-media@1.2.1--canary.19.6544149237.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
