### PR TITLE
Adds some audio stats, and distortion issue+metric

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/stats/IssueMonitor/index.js
+++ b/src/webrtc/stats/IssueMonitor/index.js
@@ -112,6 +112,15 @@ const issueDetectors = [
         enabled: ({ stats }) => stats?.pressure?.source === "cpu",
         check: ({ stats }) => stats.pressure.state === "critical",
     },
+    {
+        id: "distorted",
+        enabled: ({ hasLiveTrack, ssrc0, kind }) => hasLiveTrack && ssrc0 && kind === "audio",
+        check: ({ ssrc0 }) =>
+            ssrc0.bitrate &&
+            ssrc0.direction === "in" &&
+            ssrc0.audioLevel >= 0.001 &&
+            Math.max(ssrc0.audioConcealment, ssrc0.audioAcceleration, ssrc0.audioDeceleration) >= 0.1,
+    },
     // todo:
     // jitter/congestion - increasing jitter for several "ticks"
     // qpSum / qpf?
@@ -196,6 +205,17 @@ const metrics = [
         global: true,
         enabled: ({ stats }) => stats?.pressure?.source === "cpu",
         value: ({ stats }) => ({ nominal: 0.25, fair: 0.5, serious: 0.75, critical: 1 })[stats.pressure.state] || 0,
+    },
+    {
+        id: "distortion",
+        enabled: ({ hasLiveTrack, ssrc0, kind }) =>
+            hasLiveTrack &&
+            ssrc0 &&
+            ssrc0.bitrate &&
+            ssrc0.direction === "in" &&
+            kind === "audio" &&
+            ssrc0.audioLevel >= 0.001,
+        value: ({ ssrc0 }) => Math.max(ssrc0.audioConcealment, ssrc0.audioAcceleration, ssrc0.audioDeceleration),
     },
 ];
 

--- a/src/webrtc/stats/StatsMonitor/metrics.js
+++ b/src/webrtc/stats/StatsMonitor/metrics.js
@@ -75,6 +75,11 @@ export function captureCommonSsrcMetrics(ssrcMetrics, currentSsrcStats, prevSsrc
         ssrcMetrics.bitrate = (8000 * totalBytesDiff) / timeDiff;
         ssrcMetrics.mediaRatio = byteCountDiff / totalBytesDiff;
 
+        if (currentSsrcStats.kind === "audio") {
+            const fecBytesDiff = (currentSsrcStats.fecBytesReceived || 0) - (prevSsrcStats?.fecBytesReceived || 0);
+            ssrcMetrics.fecRatio = fecBytesDiff / byteCountDiff;
+        }
+
         const jitterBufferDelayDiff =
             (currentSsrcStats.jitterBufferDelay || 0) - (prevSsrcStats?.jitterBufferDelay || 0);
         const jitterBufferEmittedDiff =
@@ -120,6 +125,27 @@ export function captureAudioSsrcMetrics(ssrcMetrics, currentSsrcStats, prevSsrcS
         const totalSamplesDurationDiff =
             currentSsrcStats.totalSamplesDuration - (prevSsrcStats?.totalSamplesDuration || 0);
         ssrcMetrics.audioLevel = Math.sqrt(totalAudioEnergyDiff / totalSamplesDurationDiff);
+
+        const samples = currentSsrcStats.totalSamplesReceived || 0;
+        const concealmentEvents = currentSsrcStats.concealmentEvents || 0;
+        const samplesDiff = samples - (prevSsrcStats?.totalSamplesReceived || 0);
+        const concealedSamples = currentSsrcStats.concealedSamples || 0;
+        const concealedDiff = concealedSamples - (prevSsrcStats?.concealedSamples || 0);
+        const silentConcealedDiff =
+            (currentSsrcStats.silentConcealedSamples || 0) - (prevSsrcStats?.silentConcealedSamples || 0);
+        const insDiff =
+            (currentSsrcStats.insertedSamplesForDeceleration || 0) -
+            (prevSsrcStats?.insertedSamplesForDeceleration || 0);
+        const remDiff =
+            (currentSsrcStats.removedSamplesForAcceleration || 0) - (prevSsrcStats?.removedSamplesForAcceleration || 0);
+
+        ssrcMetrics.audioSamples = samples;
+        ssrcMetrics.audioConcealmentEvents = concealmentEvents;
+        ssrcMetrics.audioConcealedSamples = concealedSamples;
+        ssrcMetrics.audioConcealment = concealedDiff ? concealedDiff / samplesDiff : 0;
+        ssrcMetrics.audioSilentConcealment = silentConcealedDiff ? silentConcealedDiff / samplesDiff : 0;
+        ssrcMetrics.audioAcceleration = remDiff ? remDiff / samplesDiff : 0;
+        ssrcMetrics.audioDeceleration = insDiff ? insDiff / samplesDiff : 0;
     }
 }
 


### PR DESCRIPTION
This adds some stats, and distortion issue+metric, for our analysis.
I'm thinking we can regard everything (concealed, removed, inserted) as simply distortion. This can later drive an indicator
Also added fec ratio, to be displayed in !stats overlay

Test it using this PWA PR:
https://github.com/whereby/pwa/pull/3776

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.2--canary.21.6495986529.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.1.2--canary.21.6495986529.0
  # or 
  yarn add @whereby/jslib-media@1.1.2--canary.21.6495986529.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
