### PR TITLE
Updates compute pressure origin trials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/stats/StatsMonitor/index.js
+++ b/src/webrtc/stats/StatsMonitor/index.js
@@ -147,7 +147,7 @@ function activateComputePressureOriginTrial() {
     const otMeta = document.createElement("meta");
     otMeta.httpEquiv = "origin-trial";
 
-    // these tokens expire Oct 19th 2023
+    // these tokens expire Nov 28th 2023
     if (/hereby\.dev/.test(document.location.hostname)) {
         // *.hereby.dev
         otMeta.content =


### PR DESCRIPTION
I've updated the trials by providing feedback, but got the same tokens, so it's just updated expiration date. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.2.2--canary.22.6545111542.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.2.2--canary.22.6545111542.0
  # or 
  yarn add @whereby/jslib-media@1.2.2--canary.22.6545111542.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
