### PR TITLE
Refactor stopOrResumeVideo, handle localstream event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/tests/webrtc/webRtcHelpers.js
+++ b/tests/webrtc/webRtcHelpers.js
@@ -136,7 +136,7 @@ export function createMockedMediaStreamTrack({ kind }) {
             result.readyState = "ended";
         }),
     };
-    return result;
+    return Object.assign(new EventTarget(), result);
 }
 
 export function createMockedMediaStream() {
@@ -177,5 +177,5 @@ export function createMockedMediaStream() {
             return foundTracks[0];
         },
     };
-    return result;
+    return Object.assign(new EventTarget(), result);
 }


### PR DESCRIPTION
Extract all rtc related side-effects of stopping or resuming video into new functions. This allows the existing .stopOrResumeVideo() function to still use this logic, but also allow us to trigger the same logic on the newly introduced `stopresumevideo` event which can be dispatched on the localStream.

The rationale behind this change is to allow our new browser-sdk to get the same side-effects when toggling video, but without maintaining a direct reference to the rtc manager itself.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.3--canary.24.6639529096.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.3.3--canary.24.6639529096.0
  # or 
  yarn add @whereby/jslib-media@1.3.3--canary.24.6639529096.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
