### PR TITLE
Use absolute path in default server socket.io path constant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/utils/ServerSocket.js
+++ b/src/utils/ServerSocket.js
@@ -1,7 +1,7 @@
 import { io } from "socket.io-client";
 import adapter from "webrtc-adapter";
 
-const DEFAULT_SOCKET_PATH = "protocol/socket.io/v4";
+const DEFAULT_SOCKET_PATH = "/protocol/socket.io/v4";
 
 /**
  * Wrapper class that extends the Socket.IO client library.


### PR DESCRIPTION
Patch fix to use an absolute path as the default socket.io path in ServerSocket class.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.2--canary.25.6572224564.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.3.2--canary.25.6572224564.0
  # or 
  yarn add @whereby/jslib-media@1.3.2--canary.25.6572224564.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
