### PR TITLE
Adds getUpdatedStats for immediate stats collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",


### PR DESCRIPTION
This adds getUpdatedStats that will collect and return stats immediately (as opposed to subscribing to them and getting it pushed every 2s). Added a throttle to ensure a minimum time between stats comparisons so we don't get 0s if calling a lot inbetween those 2s.

This will be used by PWA for an experiment, detecting if peerConnection/track is in use, to enable a glitch free reconnect to signal. And an immediate remote disconnect seen from PWA if someone leaves the room instead of just being temporarily disconnected from signal.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.5--canary.27.6665188085.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.3.5--canary.27.6665188085.0
  # or 
  yarn add @whereby/jslib-media@1.3.5--canary.27.6665188085.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
