### PR TITLE
Switches rtcstats to our forked version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",
@@ -23,7 +23,7 @@
     "assert": "^2.0.0",
     "events": "^3.3.0",
     "mediasoup-client": "3.6.100",
-    "rtcstats": "github:lifeonairteam/rtcstats#v3.1.0",
+    "rtcstats": "github:whereby/rtcstats#v5.3.0",
     "sdp": "^2.2.0",
     "sdp-transform": "^2.14.1",
     "socket.io-client": "4.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4888,9 +4888,9 @@ rtcpeerconnection-shim@^1.2.15:
   dependencies:
     sdp "^2.6.0"
 
-"rtcstats@github:lifeonairteam/rtcstats#v3.1.0":
-  version "3.0.3"
-  resolved "https://codeload.github.com/lifeonairteam/rtcstats/tar.gz/8d46fedd3031ccdc52e7ec8525207e11dbb3115f"
+"rtcstats@github:whereby/rtcstats#v5.3.0":
+  version "5.3.0"
+  resolved "https://codeload.github.com/whereby/rtcstats/tar.gz/f696794035acc18a0d42229217a9a3b7630d524e"
 
 run-applescript@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This switches rtcstats to our forked version, getting rid of the chrome error on non whereby.com domains
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.3.4--canary.28.6655257686.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.3.4--canary.28.6655257686.0
  # or 
  yarn add @whereby/jslib-media@1.3.4--canary.28.6655257686.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
