### PR TITLE
Replace the 3rd party `assert` lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "format:check": "prettier --check './**/*.{js,ts,yml,json}'"
   },
   "dependencies": {
-    "assert": "^2.0.0",
     "events": "^3.3.0",
     "mediasoup-client": "3.6.100",
     "rtcstats": "github:whereby/rtcstats#v5.3.0",

--- a/src/model/RtcStream.js
+++ b/src/model/RtcStream.js
@@ -1,6 +1,5 @@
-import assert from "assert";
-
 import { TYPES as CONNECTION_STATUS_TYPES } from "./connectionStatusConstants";
+import assert from "../utils/assert";
 const CAMERA_STREAM_ID = "0";
 
 export const STREAM_TYPES = {

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -1,0 +1,75 @@
+// Source: https://github.com/browserify/commonjs-assert
+// License: MIT
+
+class AssertionError extends Error {
+    constructor(options) {
+        super(options.message);
+
+        this.name = "AssertionError";
+        this.code = "ERR_ASSERTION";
+        this.actual = options.actual;
+        this.expected = options.expected;
+        this.operator = options.operator;
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, options.stackStartFn);
+        }
+    }
+}
+
+function innerOk(fn, argLen, value, message) {
+    if (!value) {
+        let generatedMessage = false;
+
+        if (argLen === 0) {
+            generatedMessage = true;
+            message = "No value argument passed to `assert.ok()`";
+        } else if (message instanceof Error) {
+            throw message;
+        }
+
+        const err = new AssertionError({
+            actual: value,
+            expected: true,
+            message,
+            operator: "==",
+            stackStartFn: fn,
+        });
+        err.generatedMessage = generatedMessage;
+        throw err;
+    }
+}
+
+function innerFail(obj) {
+    if (obj.message instanceof Error) throw obj.message;
+
+    throw new AssertionError(obj);
+}
+
+// Pure assertion tests whether a value is truthy, as determined
+// by !!value.
+function ok(...args) {
+    innerOk(ok, args.length, ...args);
+}
+
+const assert = ok;
+
+assert.notEqual = function notEqual(actual, expected, message) {
+    if (arguments.length < 2) {
+        throw new Error("'actual' and 'expected' arguments are required");
+    }
+    // eslint-disable-next-line eqeqeq
+    if (actual == expected) {
+        innerFail({
+            actual,
+            expected,
+            message,
+            operator: "!=",
+            stackStartFn: notEqual,
+        });
+    }
+};
+
+assert.ok = ok;
+
+module.exports = assert;

--- a/src/webrtc/BaseRtcManager.js
+++ b/src/webrtc/BaseRtcManager.js
@@ -5,7 +5,7 @@ import ServerSocket from "../utils/ServerSocket";
 import * as webrtcBugDetector from "./bugDetector";
 import rtcManagerEvents from "./rtcManagerEvents";
 import Session from "./Session";
-import assert from "assert";
+import assert from "../utils/assert";
 import rtcStats from "./rtcStatsService";
 import { MAXIMUM_TURN_BANDWIDTH, MAXIMUM_TURN_BANDWIDTH_UNLIMITED, MEDIA_JITTER_BUFFER_TARGET } from "./constants";
 import adapter from "webrtc-adapter";

--- a/src/webrtc/MediaDevices.js
+++ b/src/webrtc/MediaDevices.js
@@ -1,6 +1,5 @@
-import assert from "assert";
-
 import getConstraints from "./mediaConstraints";
+import assert from "../utils/assert";
 
 export const isMobile = /mobi/i.test(navigator.userAgent);
 

--- a/src/webrtc/VegaRtcManager.js
+++ b/src/webrtc/VegaRtcManager.js
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { Device } from "mediasoup-client";
 import { PROTOCOL_REQUESTS, PROTOCOL_RESPONSES } from "../model/protocol";
 import * as CONNECTION_STATUS from "../model/connectionStatusConstants";
@@ -10,6 +9,7 @@ import VegaConnection from "./VegaConnection";
 import { getMediaSettings, modifyMediaCapabilities } from "../utils/mediaSettings";
 import { MEDIA_JITTER_BUFFER_TARGET } from "./constants";
 import { getHandler } from "../utils/getHandler";
+import assert from "../utils/assert";
 import { v4 as uuidv4 } from "uuid";
 import createMicAnalyser from "./VegaMicAnalyser";
 import { maybeTurnOnly } from "../utils/transportSettings";

--- a/tests/utils/assert.spec.js
+++ b/tests/utils/assert.spec.js
@@ -1,0 +1,73 @@
+import assert from "../../src/utils/assert";
+
+describe("assert", () => {
+    describe("ok", () => {
+        it("should throw when value is not passed", () => {
+            expect(() => {
+                assert.ok();
+            }).toThrow("No value argument passed to `assert.ok()`");
+        });
+
+        it.each`
+            value        | message
+            ${false}     | ${"false is passed"}
+            ${0}         | ${"0 is passed"}
+            ${""}        | ${"empty string is passed"}
+            ${null}      | ${"null is passed"}
+            ${undefined} | ${"undefined is passed"}
+        `("should throw an error when $message", ({ value, message }) => {
+            expect(() => {
+                assert.ok(value, message);
+            }).toThrow();
+        });
+
+        it.each`
+            value       | message
+            ${true}     | ${"true is passed"}
+            ${1}        | ${"number is passed"}
+            ${"test"}   | ${"string is passed"}
+            ${[]}       | ${"array is passed"}
+            ${{}}       | ${"object is passed"}
+            ${() => {}} | ${"function is passed"}
+        `("should not throw an error when $message", ({ value, message }) => {
+            expect(() => {
+                assert.ok(value, message);
+            }).not.toThrow();
+        });
+    });
+
+    describe("notEqual", () => {
+        it("should throw when actual and expected are not passed", () => {
+            expect(() => {
+                assert.notEqual();
+            }).toThrow("'actual' and 'expected' arguments are required");
+        });
+
+        it.each`
+            actual       | expected     | message
+            ${"test"}    | ${"test"}    | ${"strings are equal"}
+            ${1}         | ${1}         | ${"numbers are equal"}
+            ${true}      | ${true}      | ${"booleans are equal"}
+            ${null}      | ${null}      | ${"nulls are equal"}
+            ${undefined} | ${undefined} | ${"undefineds are equal"}
+            ${null}      | ${undefined} | ${"null and undefined are passed"}
+        `("should throw an error when $message", ({ actual, expected, message }) => {
+            expect(() => {
+                assert.notEqual(actual, expected, message);
+            }).toThrow();
+        });
+
+        it.each`
+            actual    | expected   | message
+            ${"test"} | ${"test1"} | ${"strings are not equal"}
+            ${1}      | ${2}       | ${"numbers are not equal"}
+            ${true}   | ${false}   | ${"booleans are not equal"}
+            ${[]}     | ${[]}      | ${"arrays are passed"}
+            ${{}}     | ${{}}      | ${"objects are passed"}
+        `("should not throw an error when $message", ({ actual, expected, message }) => {
+            expect(() => {
+                assert.notEqual(actual, expected, message);
+            }).not.toThrow();
+        });
+    });
+});

--- a/tests/webrtc/MediaDevices.spec.js
+++ b/tests/webrtc/MediaDevices.spec.js
@@ -50,6 +50,10 @@ describe("stopStreamTracks", () => {
         stream = helpers.createMockedMediaStream([videoTrack, audioTrack]);
     });
 
+    it("should throw when only is not audio or video", () => {
+        expect(() => MediaDevices.stopStreamTracks(stream, "random-string")).toThrow();
+    });
+
     it("should stop all tracks in the stream", () => {
         MediaDevices.stopStreamTracks(stream);
 

--- a/tests/webrtc/VegaRtcManager.spec.js
+++ b/tests/webrtc/VegaRtcManager.spec.js
@@ -9,6 +9,7 @@ jest.mock("webrtc-adapter", () => {
 
 import * as CONNECTION_STATUS from "../../src/model/connectionStatusConstants";
 import VegaRtcManager from "../../src/webrtc/VegaRtcManager";
+import { itShouldThrowIfMissing } from "../helpers";
 
 const originalNavigator = global.navigator;
 const originalMediasoupDevice = mediasoupClient.Device;
@@ -74,6 +75,61 @@ describe("VegaRtcManager", () => {
         });
         Object.defineProperty(mediasoupClient, "Device", {
             value: originalMediasoupDevice,
+        });
+    });
+
+    describe("constructor", () => {
+        const selfId = helpers.randomString("client-");
+        const room = { name: helpers.randomString("/room-"), iceServers: {} };
+
+        itShouldThrowIfMissing("selfId", () => {
+            //eslint-disable-next-line no-new
+            new VegaRtcManager({
+                room,
+                emitter,
+                serverSocket,
+                webrtcProvider,
+            });
+        });
+
+        itShouldThrowIfMissing("room", () => {
+            //eslint-disable-next-line no-new
+            new VegaRtcManager({
+                selfId,
+                emitter,
+                serverSocket,
+                webrtcProvider,
+            });
+        });
+
+        itShouldThrowIfMissing("emitter", () => {
+            //eslint-disable-next-line no-new
+            new VegaRtcManager({
+                selfId,
+                room,
+                serverSocket,
+                webrtcProvider,
+            });
+        });
+
+        itShouldThrowIfMissing("serverSocket", () => {
+            //eslint-disable-next-line no-new
+            new VegaRtcManager({
+                selfId,
+                room,
+                emitter,
+                webrtcProvider,
+            });
+        });
+
+        itShouldThrowIfMissing("webrtcProvider", () => {
+            //eslint-disable-next-line no-new
+            new VegaRtcManager({
+                selfId,
+                room,
+                emitter,
+                serverSocket,
+            });
         });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,17 +2011,6 @@ array-uniq@^1.0.1:
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
-assert@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/assert/-/assert-2.1.0.tgz#6d92a238d05dc02e7427c881fb8be81c8448b2dd"
-  integrity sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==
-  dependencies:
-    call-bind "^1.0.2"
-    is-nan "^1.3.2"
-    object-is "^1.1.5"
-    object.assign "^4.1.4"
-    util "^0.12.5"
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2048,11 +2037,6 @@ auto@10.29.2:
     signale "^1.4.0"
     terminal-link "^2.1.1"
     tslib "2.1.0"
-
-available-typed-arrays@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
-  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 await-to-js@^3.0.0:
   version "3.0.0"
@@ -2220,15 +2204,6 @@ bundle-name@^3.0.0:
   integrity sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==
   dependencies:
     run-applescript "^5.0.0"
-
-call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.4:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
-  integrity sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==
-  dependencies:
-    function-bind "^1.1.2"
-    get-intrinsic "^1.2.1"
-    set-function-length "^1.1.1"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -2502,28 +2477,10 @@ default-browser@^4.0.0:
     execa "^7.1.1"
     titleize "^3.0.0"
 
-define-data-property@^1.0.1, define-data-property@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.1.tgz#c35f7cd0ab09883480d12ac5cb213715587800b3"
-  integrity sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==
-  dependencies:
-    get-intrinsic "^1.2.1"
-    gopd "^1.0.1"
-    has-property-descriptors "^1.0.0"
-
 define-lazy-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
   integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
-
-define-properties@^1.1.3, define-properties@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
-  integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
-  dependencies:
-    define-data-property "^1.0.1"
-    has-property-descriptors "^1.0.0"
-    object-keys "^1.1.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2994,13 +2951,6 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-for-each@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
-  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
-  dependencies:
-    is-callable "^1.1.3"
-
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -3030,7 +2980,7 @@ fsevents@^2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-function-bind@^1.1.1, function-bind@^1.1.2:
+function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
@@ -3044,16 +2994,6 @@ get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
-get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
-  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
-  dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-proto "^1.0.1"
-    has-symbols "^1.0.3"
 
 get-monorepo-packages@^1.1.0:
   version "1.2.0"
@@ -3143,13 +3083,6 @@ globby@^7.1.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-gopd@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
-  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
-  dependencies:
-    get-intrinsic "^1.1.3"
-
 graceful-fs@^4.1.2, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -3176,35 +3109,6 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-has-property-descriptors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
-  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
-  dependencies:
-    get-intrinsic "^1.1.1"
-
-has-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
-  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
-
-has-symbols@^1.0.2, has-symbols@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
-  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
-has-tostringtag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
-  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
-  dependencies:
-    has-symbols "^1.0.2"
-
-has@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
-  integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
 
 hasown@^2.0.0:
   version "2.0.0"
@@ -3312,7 +3216,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3327,23 +3231,10 @@ io-ts@^2.1.2:
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.20.tgz#be42b75f6668a2c44f706f72ee6e4c906777c7f5"
   integrity sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==
 
-is-arguments@^1.0.4:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
-  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
-  dependencies:
-    call-bind "^1.0.2"
-    has-tostringtag "^1.0.0"
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
-
-is-callable@^1.1.3:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
-  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-core-module@^2.13.0:
   version "2.13.1"
@@ -3377,13 +3268,6 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-generator-function@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
-  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
-  dependencies:
-    has-tostringtag "^1.0.0"
-
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
@@ -3397,14 +3281,6 @@ is-inside-container@^1.0.0:
   integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
   dependencies:
     is-docker "^3.0.0"
-
-is-nan@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.3.2.tgz#043a54adea31748b55b6cd4e09aadafa69bd9e1d"
-  integrity sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==
-  dependencies:
-    call-bind "^1.0.0"
-    define-properties "^1.1.3"
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -3435,13 +3311,6 @@ is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
   integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
-
-is-typed-array@^1.1.3:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
-  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
-  dependencies:
-    which-typed-array "^1.1.11"
 
 is-unicode-supported@^0.1.0:
   version "0.1.0"
@@ -4256,29 +4125,6 @@ nwsapi@^2.2.2:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
   integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
 
-object-is@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
-  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-
-object-keys@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
-  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
-
-object.assign@^4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
-  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.4"
-    has-symbols "^1.0.3"
-    object-keys "^1.1.1"
-
 objectorarray@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/objectorarray/-/objectorarray-1.0.5.tgz#2c05248bbefabd8f43ad13b41085951aac5e68a5"
@@ -4789,16 +4635,6 @@ semver@^7.0.0, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
-set-function-length@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.1.1.tgz#4bc39fafb0307224a33e106a7d35ca1218d659ed"
-  integrity sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==
-  dependencies:
-    define-data-property "^1.1.1"
-    get-intrinsic "^1.2.1"
-    gopd "^1.0.1"
-    has-property-descriptors "^1.0.0"
-
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -5261,17 +5097,6 @@ user-home@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
 
-util@^0.12.5:
-  version "0.12.5"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
-  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
-  dependencies:
-    inherits "^2.0.3"
-    is-arguments "^1.0.4"
-    is-generator-function "^1.0.7"
-    is-typed-array "^1.1.3"
-    which-typed-array "^1.1.2"
-
 uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
@@ -5350,17 +5175,6 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
-
-which-typed-array@^1.1.11, which-typed-array@^1.1.2:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.13.tgz#870cd5be06ddb616f504e7b039c4c24898184d36"
-  integrity sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==
-  dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.4"
-    for-each "^0.3.3"
-    gopd "^1.0.1"
-    has-tostringtag "^1.0.0"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
We have encountered bundle failures on fresh browser-sdk installations with an error message stating, "Could not find module in path: 'assert/assert.js'."
Since we do not heavily depend on this package, we can resolve the issue by replacing the third-party installation.
We will accomplish this by incorporating the relevant assert functions from https://github.com/browserify/commonjs-assert into our repository.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.2--canary.32.6769211916.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.4.2--canary.32.6769211916.0
  # or 
  yarn add @whereby/jslib-media@1.4.2--canary.32.6769211916.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
