### PR TITLE
Removes cap2pBitrate feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/P2pRtcManager.js
+++ b/src/webrtc/P2pRtcManager.js
@@ -179,7 +179,7 @@ export default class P2pRtcManager extends BaseRtcManager {
         let bandwidth = this._features.bandwidth
             ? parseInt(this._features.bandwidth, 10)
             : {
-                  1: this._features.cap2pBitrate ? 1000 : 0,
+                  1: 0,
                   2: this._features.highP2PBandwidth ? 768 : 384,
                   3: this._features.highP2PBandwidth ? 512 : 256,
                   4: 192,


### PR DESCRIPTION
Removes the cap2pBitrate feature/experiment
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.3--canary.33.6771611654.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.4.3--canary.33.6771611654.0
  # or 
  yarn add @whereby/jslib-media@1.4.3--canary.33.6771611654.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
