### PR TITLE
Adds small buffer for rtcstats getStats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",


### PR DESCRIPTION
This adds a small buffer for rtcstats getStats. We need it to prevent analysis being broken in some edge cases, like when a new peerConnection's first reports could get lost while being disconnected to rtcstats - along with important initial properties that would never be sent again because of delta compression.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.4--canary.34.6809175860.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.4.4--canary.34.6809175860.0
  # or 
  yarn add @whereby/jslib-media@1.4.4--canary.34.6809175860.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
