### PR TITLE
Resets rtcstats delta compression on disconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",
@@ -22,7 +22,7 @@
   "dependencies": {
     "events": "^3.3.0",
     "mediasoup-client": "3.6.100",
-    "rtcstats": "github:whereby/rtcstats#v5.3.0",
+    "rtcstats": "github:whereby/rtcstats#5.4.0",
     "sdp": "^2.2.0",
     "sdp-transform": "^2.14.1",
     "socket.io-client": "4.7.2",

--- a/src/webrtc/rtcStatsService.js
+++ b/src/webrtc/rtcStatsService.js
@@ -14,6 +14,8 @@ const clientInfo = {
     connectionNumber: 0,
 };
 
+let resetDelta = () => {};
+
 // Inlined version of rtcstats/trace-ws with improved disconnect handling.
 function rtcStatsConnection(wsURL, logger = console) {
     const buffer = [];
@@ -109,6 +111,7 @@ function rtcStatsConnection(wsURL, logger = console) {
             ws.onclose = (e) => {
                 connection.connected = false;
                 logger.info(`[RTCSTATS] Closed ${e.code}`);
+                resetDelta();
             };
             ws.onopen = () => {
                 // send client info after each connection, so analysis tools can handle reconnections
@@ -146,11 +149,11 @@ function rtcStatsConnection(wsURL, logger = console) {
 }
 
 const server = rtcStatsConnection(process.env.RTCSTATS_URL || "wss://rtcstats.srv.whereby.com");
-rtcstats(
+resetDelta = rtcstats(
     server.trace,
     10000, // query once every 10 seconds.
     [""] // only shim unprefixed RTCPeerConnecion.
-);
+).resetDelta;
 
 const rtcStats = {
     sendEvent: (type, value) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4583,9 +4583,9 @@ rtcpeerconnection-shim@^1.2.15:
   dependencies:
     sdp "^2.6.0"
 
-"rtcstats@github:whereby/rtcstats#v5.3.0":
-  version "5.3.0"
-  resolved "https://codeload.github.com/whereby/rtcstats/tar.gz/f696794035acc18a0d42229217a9a3b7630d524e"
+"rtcstats@github:whereby/rtcstats#5.4.0":
+  version "5.4.0"
+  resolved "https://codeload.github.com/whereby/rtcstats/tar.gz/6f6623b4b53e9f6b41f530339793de227f34ea51"
 
 run-applescript@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This a follow up on https://github.com/whereby/jslib-media/pull/34

This resets delta compression when rtcstats is disconnected. This is needed in some cases when reconnecting to avoid loosing critical stats properties.

To test, watch rtcstats websocket at least 20s (to get 2 sets of getStats reports), dive in and force close it to get a new rtcstats websocket. Compare one of the reports on last getStats on old websocket with first getStats on new websocket. The old would be missing type (among others) property, but the new one should have it beacuse of the delta compression reset

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.5--canary.35.6822343274.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.4.5--canary.35.6822343274.0
  # or 
  yarn add @whereby/jslib-media@1.4.5--canary.35.6822343274.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
