### PR TITLE
Compute pressure tokens renewed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/stats/StatsMonitor/index.js
+++ b/src/webrtc/stats/StatsMonitor/index.js
@@ -149,7 +149,7 @@ function activateComputePressureOriginTrial() {
     const otMeta = document.createElement("meta");
     otMeta.httpEquiv = "origin-trial";
 
-    // these tokens expire Nov 28th 2023
+    // these tokens expire Jan 5th 2024
     if (/hereby\.dev/.test(document.location.hostname)) {
         // *.hereby.dev
         otMeta.content =


### PR DESCRIPTION
Compute Pressure Origin trial tokens was renewed by sending feedback. Same tokens, but now lasts until Jan 5th. 
The trial was supposed to end after chrome 118, but it is still active and not feature not released yet. We need to continue watching/renewing this
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.4.6--canary.38.6981555571.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.4.6--canary.38.6981555571.0
  # or 
  yarn add @whereby/jslib-media@1.4.6--canary.38.6981555571.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
