### PR TITLE
Tracks quantization metric

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/stats/IssueMonitor/index.js
+++ b/src/webrtc/stats/IssueMonitor/index.js
@@ -123,7 +123,6 @@ const issueDetectors = [
     },
     // todo:
     // jitter/congestion - increasing jitter for several "ticks"
-    // qpSum / qpf?
     // encodeTime?
     // low audio (energy)?
     // keyframe rate?
@@ -216,6 +215,12 @@ const metrics = [
             kind === "audio" &&
             ssrc0.audioLevel >= 0.001,
         value: ({ ssrc0 }) => Math.max(ssrc0.audioConcealment, ssrc0.audioAcceleration, ssrc0.audioDeceleration),
+    },
+    {
+        id: "qpf",
+        enabled: ({ hasLiveTrack, track, ssrc0, kind }) =>
+            hasLiveTrack && kind === "video" && track && ssrc0 && ssrc0.height,
+        value: ({ trackStats }) => Object.values(trackStats.ssrcs).reduce((sum, ssrc) => sum + (ssrc.qpf || 0), 0),
     },
 ];
 


### PR DESCRIPTION
This adds a quantization metric, for measuring the effect of some experimental features
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.2--canary.39.7002480240.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.5.2--canary.39.7002480240.0
  # or 
  yarn add @whereby/jslib-media@1.5.2--canary.39.7002480240.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
