### PR TITLE
Adds signal socket noop keepalive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",


### PR DESCRIPTION
This moves/commits the `brokenSignalDetectorOn` experiment previously running in PWA to jslib-media. It has been rolled out 100% for 1.5 months on PWA. It is used for faster client side disconnect detection, with a nice side effect of preventing most of the 5m periodic disconnects

A small change here is to turn on/off the noop keepalive loop when disconnected. And only apply it when using websockets (which we always do, but in case that changes...)

See also:
https://github.com/whereby/pwa/pull/3860
https://linear.app/whereby/issue/COB-187/decide-how-to-move-brokensignaldetectoron-from-experiment-to-feature
https://github.com/socketio/socket.io/issues/4868

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.3--canary.41.7017285072.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.5.3--canary.41.7017285072.0
  # or 
  yarn add @whereby/jslib-media@1.5.3--canary.41.7017285072.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
