### PR TITLE
Fix screenshare state for reconnecting p2p client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.5.3",
+  "version": "1.5.5",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/BaseRtcManager.js
+++ b/src/webrtc/BaseRtcManager.js
@@ -712,7 +712,6 @@ export default class BaseRtcManager {
 
                 const screenShareStreamId = Object.keys(this.localStreams).find((id) => id !== CAMERA_STREAM_ID);
                 if (!screenShareStreamId) {
-                    this._logger.warn("screenshare stream id not found");
                     return;
                 }
 

--- a/src/webrtc/BaseRtcManager.js
+++ b/src/webrtc/BaseRtcManager.js
@@ -705,6 +705,30 @@ export default class BaseRtcManager {
                 const answer = this._transformIncomingSdp(data.message, session.pc);
                 session.handleAnswer(answer);
             }),
+
+            // if this is a reconnect to signal-server during screen-share we must let signal-server know
+            this._serverSocket.on(PROTOCOL_RESPONSES.ROOM_JOINED, ({ room: { sfuServer: isSfu } }) => {
+                if (isSfu || !this._wasScreenSharing) return;
+
+                const screenShareStreamId = this.enabledLocalStreamIds[1];
+                if (!screenShareStreamId) {
+                    this._logger.warn("screenshare stream id not found");
+                    return;
+                }
+
+                const screenshareStream = this.localStreams[screenShareStreamId];
+                if (!screenshareStream) {
+                    this._logger.warn(`screenshare stream ${screenShareStreamId} not found`);
+                    return;
+                }
+
+                const hasAudioTrack = screenshareStream.getAudioTracks().length > 0;
+
+                this._emitServerEvent(PROTOCOL_REQUESTS.START_SCREENSHARE, {
+                    streamId: screenShareStreamId,
+                    hasAudioTrack,
+                });
+            }),
         ];
     }
 

--- a/src/webrtc/BaseRtcManager.js
+++ b/src/webrtc/BaseRtcManager.js
@@ -710,7 +710,7 @@ export default class BaseRtcManager {
             this._serverSocket.on(PROTOCOL_RESPONSES.ROOM_JOINED, ({ room: { sfuServer: isSfu } }) => {
                 if (isSfu || !this._wasScreenSharing) return;
 
-                const screenShareStreamId = this.enabledLocalStreamIds[1];
+                const screenShareStreamId = Object.keys(this.localStreams).find((id) => id !== CAMERA_STREAM_ID);
                 if (!screenShareStreamId) {
                     this._logger.warn("screenshare stream id not found");
                     return;

--- a/src/webrtc/P2pRtcManager.js
+++ b/src/webrtc/P2pRtcManager.js
@@ -380,12 +380,14 @@ export default class P2pRtcManager extends BaseRtcManager {
             streamId,
             hasAudioTrack: !!stream.getAudioTracks().length,
         });
+        this._wasScreenSharing = true;
         this._addStreamToPeerConnections(stream);
     }
 
     removeStream(streamId, stream, requestedByClientId) {
         super.removeStream(streamId, stream);
         this._removeStreamFromPeerConnections(stream);
+        this._wasScreenSharing = false;
         this._emitServerEvent(PROTOCOL_REQUESTS.STOP_SCREENSHARE, { streamId, requestedByClientId });
     }
 

--- a/tests/webrtc/baseRtcManagerSpec.js
+++ b/tests/webrtc/baseRtcManagerSpec.js
@@ -95,6 +95,57 @@ export function test(createRtcManager) {
                     rtcManager.setupSocketListeners();
                 });
 
+                describe.only(PROTOCOL_RESPONSES.ROOM_JOINED, () => {
+                    it("ignores sfu mode", () => {
+                        jest.spyOn(rtcManager, "_emitServerEvent");
+
+                        serverSocketStub.emitFromServer(PROTOCOL_RESPONSES.ROOM_JOINED, {
+                            room: {
+                                sfuServer: "bogus-sfu.whereby.com",
+                            },
+                        });
+
+                        expect(rtcManager._emitServerEvent).not.toHaveBeenCalled();
+                    });
+
+                    it("is noop if client was not screensharing", () => {
+                        jest.spyOn(rtcManager, "_emitServerEvent");
+                        const mockStream = {
+                            getAudioTracks: jest.fn(),
+                        };
+                        jest.spyOn(mockStream, "getAudioTracks").mockReturnValue([]);
+                        rtcManager._wasScreenSharing = false;
+                        rtcManager.enabledLocalStreamIds = ["0", "screenShareStreamId"];
+                        rtcManager.localStreams = { 0: {}, screenShareStreamId: mockStream };
+
+                        serverSocketStub.emitFromServer(PROTOCOL_RESPONSES.ROOM_JOINED, {
+                            room: {},
+                        });
+
+                        expect(rtcManager._emitServerEvent).not.toHaveBeenCalled();
+                    });
+
+                    it(`sends ${PROTOCOL_REQUESTS.START_SCREENSHARE} if reconnecting during screenshare`, () => {
+                        jest.spyOn(rtcManager, "_emitServerEvent");
+                        const mockStream = {
+                            getAudioTracks: jest.fn(),
+                        };
+                        jest.spyOn(mockStream, "getAudioTracks").mockReturnValue([]);
+                        rtcManager._wasScreenSharing = true;
+                        rtcManager.enabledLocalStreamIds = ["0", "screenShareStreamId"];
+                        rtcManager.localStreams = { 0: {}, screenShareStreamId: mockStream };
+
+                        serverSocketStub.emitFromServer(PROTOCOL_RESPONSES.ROOM_JOINED, {
+                            room: {},
+                        });
+
+                        expect(rtcManager._emitServerEvent).toHaveBeenCalledWith(PROTOCOL_REQUESTS.START_SCREENSHARE, {
+                            hasAudioTrack: false,
+                            streamId: "screenShareStreamId",
+                        });
+                    });
+                });
+
                 describe("READY_TO_RECEIVE_OFFER", () => {
                     it("calls rtcManager._connect", () => {
                         jest.spyOn(rtcManager, "_connect");

--- a/tests/webrtc/baseRtcManagerSpec.js
+++ b/tests/webrtc/baseRtcManagerSpec.js
@@ -95,7 +95,7 @@ export function test(createRtcManager) {
                     rtcManager.setupSocketListeners();
                 });
 
-                describe.only(PROTOCOL_RESPONSES.ROOM_JOINED, () => {
+                describe(PROTOCOL_RESPONSES.ROOM_JOINED, () => {
                     it("ignores sfu mode", () => {
                         jest.spyOn(rtcManager, "_emitServerEvent");
 


### PR DESCRIPTION
When reconnecting to signal-server, in P2P mode we don't send the `screenshare_started` request.
We do that in SFU mode.

This PR will listen for the `room_joined` response from signal-server and respond with a `screenshare_started` request if the client was screensharing when reconnecting. This will make P2P behave the same way as SFU.

# Tests to perform
## unit-tests
1. `yarn run test:unit:coverage`
2. there should be decent test coverage for the change

## manual testing
Perform the test steps below using:
1. prod p2p room (should not be glitch-free on step 4 below)
2. prod sfu room (should be glitch-free)
3. pwa in local-dev mode using this canary release (should be glitch-free)

Steps to perform:
1. connect to room with tab A and tab B using `?glitchFreeOn` query param
2. start screenshare with tab A
3. force reconnect to signal-server from tab A: `document.getElementById('app')._reactRootContainer._internalRoot.current.memoizedState.element.props.store.selectSignalSocket_()._socket.io.engine.transport.ws.close()`
5. force reconnect to signal-server from tab B: `document.getElementById('app')._reactRootContainer._internalRoot.current.memoizedState.element.props.store.selectSignalSocket_()._socket.io.engine.transport.ws.close()`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.5.6--canary.42.7112121605.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.5.6--canary.42.7112121605.0
  # or 
  yarn add @whereby/jslib-media@1.5.6--canary.42.7112121605.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
