### PR TITLE
Pin shared Github actions to 1.0.0

### DIFF
--- a/.github/workflows/merge-main-workflow.yml
+++ b/.github/workflows/merge-main-workflow.yml
@@ -7,13 +7,13 @@ on:
 jobs:
     get_version:
         name: "Get package.json version"
-        uses: whereby/github-actions/.github/workflows/check_if_version_is_incremented.yml@main
+        uses: whereby/github-actions/.github/workflows/check_if_version_is_incremented.yml@1.0.0
         with:
             source_dir: src
     draft_release:
         if: needs.get_version.outputs.new_version
         needs: get_version
         name: "Draft release"
-        uses: whereby/github-actions/.github/workflows/draft_release.yml@main
+        uses: whereby/github-actions/.github/workflows/draft_release.yml@1.0.0
         with:
             tag_name: "${{ needs.get_version.outputs.new_version }}"

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     check_version:
         name: "Check package.json version"
-        uses: whereby/github-actions/.github/workflows/check_if_version_is_incremented.yml@main
+        uses: whereby/github-actions/.github/workflows/check_if_version_is_incremented.yml@1.0.0
         with:
             source_dir: src
     test:


### PR DESCRIPTION
We ran into a regression with the shared Github actions, as every dependent repo was just referencing @main and a breaking change was committed.

The breaking change has been reverted and the 1.0.0 tag has been added to ensure we dont run into this again.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.6.1--canary.49.7540204918.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.6.1--canary.49.7540204918.0
  # or 
  yarn add @whereby/jslib-media@1.6.1--canary.49.7540204918.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
