### PR TITLE
Handle unknown track ids in replacetrack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/Session.js
+++ b/src/webrtc/Session.js
@@ -249,10 +249,6 @@ export default class Session {
         // If we didn't specify oldTrack, replace with first of its kind
         if (!oldTrack) {
             oldTrack = (senders.find((s) => s.track && s.track.kind === newTrack.kind) || {}).track;
-            if (!oldTrack) {
-                // odin: Temporary debug data, remove if you see after 2020-12-01
-                dbg("No sender with same kind! Add new track then.");
-            }
         }
         // Modern browsers makes things simple.
         if (window.RTCRtpSender && window.RTCRtpSender.prototype.replaceTrack) {
@@ -261,10 +257,6 @@ export default class Session {
                     for (let i = 0; i < senders.length; i++) {
                         const sender = senders[i];
                         const track = sender.track;
-                        if (!sender && !track) {
-                            // odin: Temporary debug data, remove if you see after 2020-12-01
-                            dbg("One of the tracks is null!");
-                        }
                         if (track.id === newTrack.id) {
                             return Promise.resolve(newTrack);
                         }

--- a/src/webrtc/Session.js
+++ b/src/webrtc/Session.js
@@ -246,8 +246,8 @@ export default class Session {
         if (!senders.length) {
             dbg("No senders!");
         }
-        // If we didn't specify oldTrack, replace with first of its kind
-        if (!oldTrack) {
+        // If we didn't specify oldTrack, or both track ids are unknown, replace with first of its kind
+        if (!oldTrack || senders.every((s) => s.track?.id !== oldTrack.id && s.track?.id !== newTrack.id)) {
             oldTrack = (senders.find((s) => s.track && s.track.kind === newTrack.kind) || {}).track;
         }
         // Modern browsers makes things simple.


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.2--canary.50.7640985927.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.7.2--canary.50.7640985927.0
  # or 
  yarn add @whereby/jslib-media@1.7.2--canary.50.7640985927.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
