### PR TITLE
Allow explicit device handler factory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,4 @@ module.exports = {
     testMatch: ["<rootDir>/tests/**/?(*.)+(spec|test).[jt]s?(x)"],
     roots: ["<rootDir>"],
     coverageDirectory: "test-report/unit-tests",
-    transformIgnorePatterns: ["node_modules/(?!ip-regex)"],
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "check-ip": "^1.1.1",
     "events": "^3.3.0",
     "ip-address": "^9.0.5",
-    "ip-regex": "^5.0.0",
     "mediasoup-client": "3.6.100",
     "rtcstats": "github:whereby/rtcstats#5.4.0",
     "sdp": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/utils/ipRegex.js
+++ b/src/utils/ipRegex.js
@@ -1,0 +1,46 @@
+// taken from https://github.com/sindresorhus/ip-regex ^5.0.0
+// inlined because it's import caused errors in browser-sdk when running tests
+const word = "[a-fA-F\\d:]";
+
+const boundry = (options) =>
+    options && options.includeBoundaries ? `(?:(?<=\\s|^)(?=${word})|(?<=${word})(?=\\s|$))` : "";
+
+const v4 = "(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}";
+
+const v6segment = "[a-fA-F\\d]{1,4}";
+
+const v6 = `
+(?:
+(?:${v6segment}:){7}(?:${v6segment}|:)|                                    // 1:2:3:4:5:6:7::  1:2:3:4:5:6:7:8
+(?:${v6segment}:){6}(?:${v4}|:${v6segment}|:)|                             // 1:2:3:4:5:6::    1:2:3:4:5:6::8   1:2:3:4:5:6::8  1:2:3:4:5:6::1.2.3.4
+(?:${v6segment}:){5}(?::${v4}|(?::${v6segment}){1,2}|:)|                   // 1:2:3:4:5::      1:2:3:4:5::7:8   1:2:3:4:5::8    1:2:3:4:5::7:1.2.3.4
+(?:${v6segment}:){4}(?:(?::${v6segment}){0,1}:${v4}|(?::${v6segment}){1,3}|:)| // 1:2:3:4::        1:2:3:4::6:7:8   1:2:3:4::8      1:2:3:4::6:7:1.2.3.4
+(?:${v6segment}:){3}(?:(?::${v6segment}){0,2}:${v4}|(?::${v6segment}){1,4}|:)| // 1:2:3::          1:2:3::5:6:7:8   1:2:3::8        1:2:3::5:6:7:1.2.3.4
+(?:${v6segment}:){2}(?:(?::${v6segment}){0,3}:${v4}|(?::${v6segment}){1,5}|:)| // 1:2::            1:2::4:5:6:7:8   1:2::8          1:2::4:5:6:7:1.2.3.4
+(?:${v6segment}:){1}(?:(?::${v6segment}){0,4}:${v4}|(?::${v6segment}){1,6}|:)| // 1::              1::3:4:5:6:7:8   1::8            1::3:4:5:6:7:1.2.3.4
+(?::(?:(?::${v6segment}){0,5}:${v4}|(?::${v6segment}){1,7}|:))             // ::2:3:4:5:6:7:8  ::2:3:4:5:6:7:8  ::8             ::1.2.3.4
+)(?:%[0-9a-zA-Z]{1,})?                                             // %eth0            %1
+`
+    .replace(/\s*\/\/.*$/gm, "")
+    .replace(/\n/g, "")
+    .trim();
+
+// Pre-compile only the exact regexes because adding a global flag make regexes stateful
+const v46Exact = new RegExp(`(?:^${v4}$)|(?:^${v6}$)`);
+const v4exact = new RegExp(`^${v4}$`);
+const v6exact = new RegExp(`^${v6}$`);
+
+const ipRegex = (options) =>
+    options && options.exact
+        ? v46Exact
+        : new RegExp(
+              `(?:${boundry(options)}${v4}${boundry(options)})|(?:${boundry(options)}${v6}${boundry(options)})`,
+              "g"
+          );
+
+ipRegex.v4 = (options) =>
+    options && options.exact ? v4exact : new RegExp(`${boundry(options)}${v4}${boundry(options)}`, "g");
+ipRegex.v6 = (options) =>
+    options && options.exact ? v6exact : new RegExp(`${boundry(options)}${v6}${boundry(options)}`, "g");
+
+export default ipRegex;

--- a/src/webrtc/P2pRtcManager.js
+++ b/src/webrtc/P2pRtcManager.js
@@ -5,7 +5,7 @@ import RtcStream from "../model/RtcStream";
 import { getOptimalBitrate } from "../utils/optimalBitrate";
 import { setCodecPreferenceSDP } from "./sdpModifier";
 import adapter from "webrtc-adapter";
-import ipRegex from "ip-regex";
+import ipRegex from "../utils/ipRegex";
 import { Address6 } from "ip-address";
 import checkIp from "check-ip";
 import validate from "uuid-validate";

--- a/src/webrtc/RtcManagerDispatcher.js
+++ b/src/webrtc/RtcManagerDispatcher.js
@@ -9,7 +9,16 @@ export default class RtcManagerDispatcher {
         this.currentManager = null;
         serverSocket.on(PROTOCOL_RESPONSES.ROOM_JOINED, ({ room, selfId, error, eventClaim }) => {
             if (error) return; // ignore error responses which lack room
-            const config = { selfId, room, emitter, serverSocket, webrtcProvider, features, eventClaim };
+            const config = {
+                selfId,
+                room,
+                emitter,
+                serverSocket,
+                webrtcProvider,
+                features,
+                eventClaim,
+                deviceHandlerFactory: features?.deviceHandlerFactory,
+            };
             const isSfu = !!room.sfuServer;
             if (this.currentManager) {
                 if (this.currentManager.isInitializedWith({ selfId, roomName: room.name, isSfu })) {

--- a/src/webrtc/VegaRtcManager.js
+++ b/src/webrtc/VegaRtcManager.js
@@ -26,7 +26,17 @@ const OUTBOUND_SCREEN_OUTBOUND_STREAM_ID = uuidv4();
 if (browserName === "chrome") window.document.addEventListener("beforeunload", () => (unloading = true));
 
 export default class VegaRtcManager {
-    constructor({ selfId, room, emitter, serverSocket, webrtcProvider, features, eventClaim, logger = console }) {
+    constructor({
+        selfId,
+        room,
+        emitter,
+        serverSocket,
+        webrtcProvider,
+        features,
+        eventClaim,
+        logger = console,
+        deviceHandlerFactory,
+    }) {
         assert.ok(selfId, "selfId is required");
         assert.ok(room, "room is required");
         assert.ok(emitter && emitter.emit, "emitter is required");
@@ -50,7 +60,12 @@ export default class VegaRtcManager {
         this._micAnalyser = null;
         this._micAnalyserDebugger = null;
 
-        this._mediasoupDevice = new Device({ handlerName: getHandler() });
+        if (deviceHandlerFactory) {
+            this._mediasoupDevice = new Device({ handlerFactory: deviceHandlerFactory });
+        } else {
+            this._mediasoupDevice = new Device({ handlerName: getHandler() });
+        }
+
         this._routerRtpCapabilities = null;
 
         this._sendTransport = null;

--- a/src/webrtc/rtcStatsService.js
+++ b/src/webrtc/rtcStatsService.js
@@ -14,7 +14,8 @@ const clientInfo = {
     connectionNumber: 0,
 };
 
-let resetDelta = () => {};
+const noop = () => {};
+let resetDelta = noop;
 
 // Inlined version of rtcstats/trace-ws with improved disconnect handling.
 function rtcStatsConnection(wsURL, logger = console) {
@@ -149,11 +150,13 @@ function rtcStatsConnection(wsURL, logger = console) {
 }
 
 const server = rtcStatsConnection(process.env.RTCSTATS_URL || "wss://rtcstats.srv.whereby.com");
-resetDelta = rtcstats(
+const stats = rtcstats(
     server.trace,
     10000, // query once every 10 seconds.
     [""] // only shim unprefixed RTCPeerConnecion.
-).resetDelta;
+);
+// on node clients this function can be undefined
+resetDelta = stats?.resetDelta || noop;
 
 const rtcStats = {
     sendEvent: (type, value) => {

--- a/tests/webrtc/VegaRtcManager.spec.js
+++ b/tests/webrtc/VegaRtcManager.spec.js
@@ -131,6 +131,27 @@ describe("VegaRtcManager", () => {
                 serverSocket,
             });
         });
+
+        it("handles custom device handler factories", () => {
+            const deviceHandlerFactory = function () {};
+            jest.mock("mediasoup-client", () => {
+                return {
+                    Device: jest.fn().mockImplementation(() => {
+                        return {};
+                    }),
+                };
+            });
+            //eslint-disable-next-line no-new
+            new VegaRtcManager({
+                selfId,
+                room,
+                emitter,
+                serverSocket,
+                webrtcProvider,
+                deviceHandlerFactory,
+            });
+            expect(mediasoupClient.Device).toHaveBeenCalledWith({ handlerFactory: deviceHandlerFactory });
+        });
     });
 
     describe("stopOrResumeVideo", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3258,11 +3258,6 @@ ip-range-check@^0.0.2:
   dependencies:
     ipaddr.js "^1.0.1"
 
-ip-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-5.0.0.tgz#cd313b2ae9c80c07bd3851e12bf4fa4dc5480632"
-  integrity sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==
-
 ipaddr.js@^1.0.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"


### PR DESCRIPTION
We need a custom device handler for Node clients using the Werift library. We don't know which handler works best (or whether we need to write our own to handle Node clients), so I think allowing the client to provide a handler is the easiest option.

### To Test
It's a bit of a pain with the Node client still in development... Easiest with [yalc](https://github.com/wclr/yalc)
- clone [the browser sdk branch targeting this branch](https://github.com/whereby/browser-sdk/pull/171) and run `yarn build && yalc publish`
- clone [the node-sdk-test repo](https://github.com/whereby/node-sdk-test) and `yalc add @whereby.com/browser-sdk@2.0.0-beta3 && yarn`
- in that dir, add a room to .env like so:
```
ROOM_URL=https://team.whereby.com/%YOUR_ROOM%
ROOM_NAME=/%YOUR_ROOM%
```
- open your chosen room in a browser
- yarn start
- see the transcriber client join the room

if you want to see what happens without these changes, do the above but before you `yarn build && yalc publish` the browser-sdk repo, change the `jslib-media` entry in `package.json` to `"@whereby/jslib-media": "whereby/jslib-media.git#1.7.1",`
You'll see an error like `UnsupportedError: device not supported` when trying to `yarn start` the node-sdk-test

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.3--canary.52.7712225210.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.7.3--canary.52.7712225210.0
  # or 
  yarn add @whereby/jslib-media@1.7.3--canary.52.7712225210.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
