### PR TITLE
Improve bad-network issue detector check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/stats/IssueMonitor/index.js
+++ b/src/webrtc/stats/IssueMonitor/index.js
@@ -90,15 +90,14 @@ const issueDetectors = [
         check: ({ ssrc0 }) => ssrc0.fps < 10,
     },
     {
-        id: "bad-network", // this drives quality-indicator
+        id: "bad-network",
         enabled: ({ hasLiveTrack, ssrc0 }) => hasLiveTrack && ssrc0,
-        check: ({ ssrc0, ssrcs, kind, client }) =>
+        check: ({ ssrc0, kind, client }) =>
             ssrc0.bitrate === 0 ||
             ssrc0.lossRatio > 0.03 ||
             (ssrc0.fractionLost || 0) > 0.03 ||
             (!client.isPresentation && kind === "video" && ssrc0.bitrate < 30000) ||
-            (ssrc0.direction === "in" && ssrc0.pliRate > 2) ||
-            ssrcs.find((ssrc) => ssrc.qualityLimitationReason === "bandwidth"),
+            (ssrc0.direction === "in" && ssrc0.pliRate > 2),
     },
     {
         id: "cpu-pressure-serious",


### PR DESCRIPTION
Remove `qualityLimitationReason === "bandwidth"` from the `bad-network` issue detection calculation.

This value takes a long-time to recover after e.g. high packet-loss has already ended.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.2--canary.53.7668924857.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.7.2--canary.53.7668924857.0
  # or 
  yarn add @whereby/jslib-media@1.7.2--canary.53.7668924857.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
