### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 10


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.5--canary.56.7817106522.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.7.5--canary.56.7817106522.0
  # or 
  yarn add @whereby/jslib-media@1.7.5--canary.56.7817106522.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
