### PR TITLE
Compute pressure tokens updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/stats/StatsMonitor/index.js
+++ b/src/webrtc/stats/StatsMonitor/index.js
@@ -152,7 +152,7 @@ function activateComputePressureOriginTrial() {
     const otMeta = document.createElement("meta");
     otMeta.httpEquiv = "origin-trial";
 
-    // these tokens expire Feb 15th 2024
+    // these tokens expire March 22th 2024
     if (/hereby\.dev/.test(document.location.hostname)) {
         // *.hereby.dev
         otMeta.content =


### PR DESCRIPTION
Compute pressure origin trial tokens has been renewed. same tokens as before, no need to deploy/publish
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.7.6--canary.57.7841280852.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.7.6--canary.57.7841280852.0
  # or 
  yarn add @whereby/jslib-media@1.7.6--canary.57.7841280852.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
