### PR TITLE
Reverses offer/answer role on sld failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.7.6",
+  "version": "1.8.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",


### PR DESCRIPTION
This reverses the offer/answer role when we fail to set local description from offer generated. We will run this as an experiment to see if it can help some users on buggy(?) devices/browsers.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.8.1--canary.69.7887303967.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.8.1--canary.69.7887303967.0
  # or 
  yarn add @whereby/jslib-media@1.8.1--canary.69.7887303967.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
