### PR TITLE
Add desync issue to stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/stats/IssueMonitor/index.js
+++ b/src/webrtc/stats/IssueMonitor/index.js
@@ -322,6 +322,8 @@ function onUpdatedStats(statsByView, clients) {
         ["video", "audio", "global"].forEach((kind) => {
             // skip checking muted/disabled tracks if not global
             if (!(kind === "global" && !client.isPresentation) && !client[kind]?.enabled) return;
+            // don't check global for remote clients
+            if (kind === "global" && !client.isLocalClient) return;
 
             let issuesAndMetrics = issuesAndMetricsByView[client.id];
             if (!issuesAndMetrics) {

--- a/src/webrtc/stats/IssueMonitor/index.js
+++ b/src/webrtc/stats/IssueMonitor/index.js
@@ -405,13 +405,13 @@ function onUpdatedStats(statsByView, clients) {
                 }
             });
 
-            issueDetectors.forEach((isssueDetector) => {
-                if (isssueDetector.global && kind !== "global") return;
-                if (!isssueDetector.global && kind === "global") return;
+            issueDetectors.forEach((issueDetector) => {
+                if (issueDetector.global && kind !== "global") return;
+                if (!issueDetector.global && kind === "global") return;
 
-                const issueKey = `${qualifierString}-${isssueDetector.id}`;
+                const issueKey = `${qualifierString}-${issueDetector.id}`;
 
-                const enabled = isssueDetector.enabled ? isssueDetector.enabled(checkData) : true;
+                const enabled = issueDetector.enabled ? issueDetector.enabled(checkData) : true;
 
                 let issueData = issuesAndMetrics.issues[issueKey];
                 let aggregatedIssueData = aggregatedIssues[issueKey];
@@ -446,7 +446,7 @@ function onUpdatedStats(statsByView, clients) {
                     aggregatedIssueData.ticks++;
                     aggregatedIssueData.curTicks++;
 
-                    const issueDetected = isssueDetector.check?.(checkData);
+                    const issueDetected = issueDetector.check?.(checkData);
                     if (issueDetected) {
                         issueData.registered++;
                         issueData.current++;


### PR DESCRIPTION
This PR will:
1. add desync issue to stats
2. stop checking global issues/metrics for remote clients
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.2--canary.70.7932506468.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.9.2--canary.70.7932506468.0
  # or 
  yarn add @whereby/jslib-media@1.9.2--canary.70.7932506468.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
