### PR TITLE
Remove internal devDependencies

### DIFF
--- a/.autorc.json
+++ b/.autorc.json
@@ -1,0 +1,4 @@
+{
+    "author": "Whereby Bot <ops+gocd-github@whereby.com>",
+    "plugins": ["npm"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
         "jest/globals": true,
         "node": true
     },
-    "extends": ["@whereby/eslint-config/browser", "prettier"],
+    "extends": ["./config/eslint/browser", "prettier"],
     "parserOptions": {
         "sourceType": "module",
         "requireConfigFile": false

--- a/config/eslint/browser.js
+++ b/config/eslint/browser.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "extends": "./es6.js",
+    "env": {
+        "browser": true
+    }
+};

--- a/config/eslint/es6.js
+++ b/config/eslint/es6.js
@@ -1,0 +1,111 @@
+module.exports = {
+    "env": {
+        "builtin": true,
+        "es6": true
+    },
+    "plugins": [],
+    "rules": {
+        "arrow-parens": [2, "as-needed", { "requireForBlockBody": true }],
+        "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+        "block-scoped-var": 2,
+        "camelcase": 2,
+        "comma-dangle": ["error", "always-multiline"],
+        "comma-style": [2, "last"],
+        "comma-spacing": 2,
+        "consistent-return": 0,
+        "curly": [
+            2,
+            "all"
+        ],
+        "dot-notation": [
+            0,
+            {
+                "allowKeywords": true
+            }
+        ],
+        "eol-last": 2,
+        "eqeqeq": [
+            2
+        ],
+        "guard-for-in": 2,
+        "handle-callback-err": 2,
+        "indent": [2, 4, {"SwitchCase": 1}],
+        "key-spacing": 2,
+        "new-cap": 2,
+        "no-new-func": 2,
+        "array-callback-return": 2,
+        "no-array-constructor": 2,
+        "no-bitwise": 2,
+        "no-caller": 2,
+        "no-cond-assign": [
+            2,
+            "always"
+        ],
+        "no-confusing-arrow": 2,
+        "no-console": 2,
+        "no-const-assign": 2,
+        "no-debugger": 2,
+        "no-dupe-class-members": 2,
+        "no-duplicate-imports": 2,
+        "no-empty": 0,
+        "no-extra-boolean-cast": 0,
+        "no-eval": 2,
+        "no-extend-native": 2,
+        "no-extra-bind": 2,
+        "no-extra-parens": 0,
+        "no-irregular-whitespace": 2,
+        "no-iterator": 2,
+        "no-loop-func": 2,
+        "no-multiple-empty-lines": [
+            2,
+            {
+                "max": 1
+            }
+        ],
+        "no-multi-spaces": 2,
+        "no-multi-str": 2,
+        "no-native-reassign": 2,
+        "no-new": 2,
+        "no-new-object": 2,
+        "no-path-concat": 0,
+        "no-plusplus": 0,
+        "no-process-exit": 0,
+        "no-proto": 2,
+        "no-redeclare": 2,
+        "no-return-assign": 2,
+        "no-script-url": 2,
+        "no-sequences": 2,
+        "no-shadow": 0,
+        "no-spaced-func": 2,
+        "no-trailing-spaces": 2,
+        "no-underscore-dangle": 0,
+        "no-undef": 2,
+        "no-unused-vars": 2,
+        "no-use-before-define": 2,
+        "no-useless-constructor": 2,
+        "no-var": 2,
+        "no-with": 2,
+        "object-shorthand": 2,
+        "one-var": [2, "never"],
+        "prefer-arrow-callback": 2,
+        "prefer-const": 2,
+        "quotes": [2, "double", {
+            "avoidEscape": true,
+            "allowTemplateLiterals": true
+        }],
+        "no-unreachable": 2,
+
+        "semi": [
+            2,
+            "always"
+        ],
+        "semi-spacing": 2,
+        "space-infix-ops": 2,
+        "space-unary-ops": 0,
+        "strict": [2, "global"],
+        "valid-typeof": 2,
+        "wrap-iife": [
+            2,"any"
+        ]
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",
@@ -34,11 +34,11 @@
     "webrtc-adapter": "^7.3.0"
   },
   "devDependencies": {
+    "@auto-it/npm": "^10.29.2",
     "@babel/core": "^7.23.2",
     "@babel/eslint-parser": "^7.22.15",
     "@babel/preset-env": "^7.23.2",
-    "@whereby/auto-config": "0.0.2",
-    "@whereby/eslint-config": "5.0.4",
+    "auto": "10.29.2",
     "babel-jest": "^29.7.0",
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
@@ -54,5 +54,8 @@
   },
   "engines": {
     "node": ">=16.0.0"
+  },
+  "auto": {
+    "extends": "./.autorc.json"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1437,7 +1437,12 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
@@ -1869,19 +1874,6 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@whereby/auto-config@0.0.2":
-  version "0.0.2"
-  resolved "https://npm.pkg.github.com/download/@whereby/auto-config/0.0.2/c0e436c04c0a144acc9c49c71e21d2b3d523062e#c0e436c04c0a144acc9c49c71e21d2b3d523062e"
-  integrity sha512-AHmOUq/vs/wmsiWRxIwNiEe9zo3plFuAUkph71vJuqPr9BzzuhmZmLtL5uWLNsZhTx/UYSYjxBzGm/d6v2QDpg==
-  dependencies:
-    "@auto-it/npm" "^10.29.2"
-    auto "10.29.2"
-
-"@whereby/eslint-config@5.0.4":
-  version "5.0.4"
-  resolved "https://npm.pkg.github.com/download/@whereby/eslint-config/5.0.4/9242f519d0a3dbdcd8d81d033ac2c6e029e63ba4#9242f519d0a3dbdcd8d81d033ac2c6e029e63ba4"
-  integrity sha512-dperUZ8TXg05bwYI2AwqpCO7VHfNgEa1Yk+87j6FmKoZ/5TzQKe3GL69zFwGaxjE1m7J+lgd+iJqBjxJYDhNeg==
-
 abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -1900,15 +1892,25 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.0.2, acorn-walk@^8.1.1:
+acorn-walk@^8.0.2:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.1.tgz#2f10f5b69329d90ae18c58bf1fa8fccd8b959a43"
   integrity sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==
 
-acorn@^8.1.0, acorn@^8.4.1, acorn@^8.8.1, acorn@^8.9.0:
+acorn-walk@^8.1.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
+  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
+acorn@^8.1.0, acorn@^8.8.1, acorn@^8.9.0:
   version "8.11.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
   integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
+
+acorn@^8.4.1:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 agent-base@6:
   version "6.0.2"
@@ -2973,9 +2975,9 @@ form-data@^4.0.0:
     mime-types "^2.1.12"
 
 fp-ts@^2.5.3:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.16.1.tgz#6abc401ce42b65364ca8f0b0d995c5840c68a930"
-  integrity sha512-by7U5W8dkIzcvDofUcO42yl9JbnHTEDBrzu3pt5fKT+Z4Oy85I21K80EYJYdjQGC2qum4Vo55Ag57iiIK4FYuA==
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.16.2.tgz#7faa90f6fc2e8cf84c711d2c4e606afe2be9e342"
+  integrity sha512-CkqAjnIKFqvo3sCyoBTqgJvF+bHrSik584S9nhTjtBESLx26cbtVMR/T9a6ApChOcSDAaM3JydDmWDUn4EEXng==
 
 fromentries@^1.2.0, fromentries@^1.3.2:
   version "1.3.2"
@@ -4660,7 +4662,14 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
+semver@^7.0.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==


### PR DESCRIPTION
We are seeing some problems from our customers when installing our browser-sdk package. This is because we rely on some internal private repos for development.

Originially we thought this would not be an issue, but it seems like we were wrong. For now, copy the eslint config into this repo. This will most likely be short-lived, as we are planning to move this library into our new monorepo setup.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.1--canary.71.7929280079.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.9.1--canary.71.7929280079.0
  # or 
  yarn add @whereby/jslib-media@1.9.1--canary.71.7929280079.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
