### PR TITLE
Remove fps24 option from getMediaConstraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/mediaConstraints.js
+++ b/src/webrtc/mediaConstraints.js
@@ -11,7 +11,6 @@ const parseResolution = (res) => res.split(/[^\d]/g).map((n) => parseInt(n, 10))
 export function getMediaConstraints({
     disableAEC,
     disableAGC,
-    fps24,
     hd,
     lax,
     lowDataMode,
@@ -22,7 +21,6 @@ export function getMediaConstraints({
 }) {
     let HIGH_HEIGHT = 480;
     let LOW_HEIGHT = 240;
-    let NON_STANDARD_FPS = 0;
 
     if (hd) {
         // respect user choice, but default to HD for pro, and SD for free
@@ -37,18 +35,14 @@ export function getMediaConstraints({
         }
     }
 
-    // Set framerate to 24 to increase quality/bandwidth
-    if (fps24) NON_STANDARD_FPS = 24;
-
-    // Set framerate for low data, but only for non-simulcast
-    if (lowDataMode && !simulcast) NON_STANDARD_FPS = 15;
-
     const constraints = {
         audio: { ...(preferredDeviceIds.audioId && { deviceId: preferredDeviceIds.audioId }) },
         video: {
             ...(preferredDeviceIds.videoId ? { deviceId: preferredDeviceIds.videoId } : { facingMode: "user" }),
             height: lowDataMode ? LOW_HEIGHT : HIGH_HEIGHT,
-            ...(NON_STANDARD_FPS && { frameRate: NON_STANDARD_FPS }),
+            // Set a lower frame rate (15fps) for low data, but only for non-simulcast.
+            // Otherwise use 24fps to increase quality/bandwidth.
+            frameRate: lowDataMode && !simulcast ? 15 : 24,
         },
     };
     if (lax) {

--- a/tests/webrtc/mediaConstraints.spec.js
+++ b/tests/webrtc/mediaConstraints.spec.js
@@ -1,4 +1,4 @@
-import getConstraints from "../../src/webrtc/mediaConstraints";
+import getConstraints, { getMediaConstraints } from "../../src/webrtc/mediaConstraints";
 
 // the selectGetConstraintsOptions is testing most permutations of this
 describe("getConstraints", () => {
@@ -15,17 +15,24 @@ describe("getConstraints", () => {
 
         expect(result).toEqual({ video: expect.any(Object) });
     });
+});
 
-    it("should set fps to 24 if fps24 is true", () => {
-        const result = getConstraints({ devices: [vdev1], options: { fps24: true, hd: true } });
+describe("getMediaConstraints", () => {
+    describe("frameRate", () => {
+        it.each`
+            lowDataMode | simulcast | expected
+            ${false}    | ${false}  | ${24}
+            ${true}     | ${false}  | ${15}
+            ${true}     | ${true}   | ${24}
+        `(
+            "should set frameRate to $expected if lowDataMode is $lowDataMode and simulcast is $simulcast",
+            ({ lowDataMode, simulcast, expected }) => {
+                const preferredDeviceIds = { audioId: "audioId", videoId: "videoId" };
 
-        expect(result).toEqual({
-            video: {
-                aspectRatio: 1.3333333333333333,
-                facingMode: "user",
-                frameRate: 24,
-                height: { ideal: 720, min: 360 },
-            },
-        });
+                const result = getMediaConstraints({ lowDataMode, preferredDeviceIds, simulcast });
+
+                expect(result.video.frameRate).toBe(expected);
+            }
+        );
     });
 });


### PR DESCRIPTION
This flag was added here: https://github.com/whereby/jslib-media/pull/37

But now it is enabled for everyone, so it's value can be _hard coded_ and the option can be removed.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.6--canary.82.8062035262.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.9.6--canary.82.8062035262.0
  # or 
  yarn add @whereby/jslib-media@1.9.6--canary.82.8062035262.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
