### PR TITLE
Bump version to 1.9.6 after updating deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.7--canary.87.8137721964.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.9.7--canary.87.8137721964.0
  # or 
  yarn add @whereby/jslib-media@1.9.7--canary.87.8137721964.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
