### PR TITLE
Fix adapter imports for sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/utils/ServerSocket.js
+++ b/src/utils/ServerSocket.js
@@ -1,7 +1,9 @@
 import { io } from "socket.io-client";
-import adapter from "webrtc-adapter";
+import adapterRaw from "webrtc-adapter";
 import { ReconnectManager } from "./ReconnectManager";
 import { PROTOCOL_RESPONSES } from "../model/protocol";
+
+const adapter = adapterRaw.default ?? adapterRaw;
 
 const DEFAULT_SOCKET_PATH = "/protocol/socket.io/v4";
 

--- a/src/webrtc/P2pRtcManager.js
+++ b/src/webrtc/P2pRtcManager.js
@@ -9,7 +9,7 @@ import * as CONNECTION_STATUS from "../model/connectionStatusConstants";
 import RtcStream from "../model/RtcStream";
 import { getOptimalBitrate } from "../utils/optimalBitrate";
 import { setCodecPreferenceSDP, addAbsCaptureTimeExtMap } from "./sdpModifier";
-import adapter from "webrtc-adapter";
+import adapterRaw from "webrtc-adapter";
 import ipRegex from "../utils/ipRegex";
 import { Address6 } from "ip-address";
 import checkIp from "check-ip";
@@ -17,6 +17,7 @@ import validate from "uuid-validate";
 import rtcManagerEvents from "./rtcManagerEvents";
 import Logger from "../utils/Logger";
 
+const adapter = adapterRaw.default ?? adapterRaw;
 const logger = new Logger();
 
 const ICE_PUBLIC_IP_GATHERING_TIMEOUT = 3 * 1000;

--- a/src/webrtc/Session.js
+++ b/src/webrtc/Session.js
@@ -1,10 +1,11 @@
 import * as sdpModifier from "./sdpModifier";
 import * as statsHelper from "./statsHelper";
 import { setVideoBandwidthUsingSetParameters } from "./rtcrtpsenderHelper";
-import adapter from "webrtc-adapter";
+import adapterRaw from "webrtc-adapter";
 import { MAXIMUM_TURN_BANDWIDTH_UNLIMITED } from "./constants";
 import Logger from "../utils/Logger";
 
+const adapter = adapterRaw.default ?? adapterRaw;
 const logger = new Logger();
 
 export default class Session {

--- a/src/webrtc/VegaRtcManager.js
+++ b/src/webrtc/VegaRtcManager.js
@@ -4,7 +4,7 @@ import * as CONNECTION_STATUS from "../model/connectionStatusConstants";
 import ServerSocket from "../utils/ServerSocket";
 import rtcManagerEvents from "./rtcManagerEvents";
 import rtcStats from "./rtcStatsService";
-import adapter from "webrtc-adapter";
+import adapterRaw from "webrtc-adapter";
 import VegaConnection from "./VegaConnection";
 import { getMediaSettings, modifyMediaCapabilities } from "../utils/mediaSettings";
 import { MEDIA_JITTER_BUFFER_TARGET } from "./constants";
@@ -16,6 +16,7 @@ import { maybeTurnOnly } from "../utils/transportSettings";
 import VegaMediaQualityMonitor from "./VegaMediaQualityMonitor";
 import Logger from "../utils/Logger";
 
+const adapter = adapterRaw.default ?? adapterRaw;
 const logger = new Logger();
 
 const browserName = adapter.browserDetails.browser;

--- a/src/webrtc/bugDetector.js
+++ b/src/webrtc/bugDetector.js
@@ -1,4 +1,6 @@
-import adapter from "webrtc-adapter";
+import adapterRaw from "webrtc-adapter";
+
+const adapter = adapterRaw.default ?? adapterRaw;
 
 /**
  * Detect mic issue which seems to happen on OSX when the computer is woken up and sleeping

--- a/src/webrtc/mediaConstraints.js
+++ b/src/webrtc/mediaConstraints.js
@@ -1,4 +1,6 @@
-import adapter from "webrtc-adapter";
+import adapterRaw from "webrtc-adapter";
+
+const adapter = adapterRaw.default ?? adapterRaw;
 
 const isSafari = adapter.browserDetails.browser === "safari";
 

--- a/src/webrtc/rtcStatsService.js
+++ b/src/webrtc/rtcStatsService.js
@@ -1,7 +1,9 @@
 // ensure adapter is loaded first.
-import adapter from "webrtc-adapter"; // eslint-disable-line no-unused-vars
+import adapterRaw from "webrtc-adapter";
 import rtcstats from "rtcstats";
 import { v4 as uuidv4 } from "uuid";
+
+const adapter = adapterRaw.default ?? adapterRaw; // eslint-disable-line no-unused-vars
 
 const RTCSTATS_PROTOCOL_VERSION = "1.0";
 

--- a/src/webrtc/sdpModifier.js
+++ b/src/webrtc/sdpModifier.js
@@ -1,8 +1,9 @@
 import SDPUtils from "sdp";
-import adapter from "webrtc-adapter";
+import adapterRaw from "webrtc-adapter";
 import * as sdpTransform from "sdp-transform";
 import Logger from "../utils/Logger";
 
+const adapter = adapterRaw.default ?? adapterRaw;
 const logger = new Logger();
 
 const browserName = adapter.browserDetails.browser;


### PR DESCRIPTION
There's a confusion in ESM and CJS, let's try to fix them by using `default` wrapper removal for `adapter` (as suggested here: https://github.com/reduxjs/redux-toolkit/issues/1960).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.8--canary.89.8267611592.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.9.8--canary.89.8267611592.0
  # or 
  yarn add @whereby/jslib-media@1.9.8--canary.89.8267611592.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
