### PR TITLE
Improve test coverage of media helper functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@whereby/jslib-media",
   "description": "Media library for Whereby",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "private": false,
   "license": "MIT",
   "homepage": "https://github.com/whereby/jslib-media",

--- a/src/webrtc/MediaDevices.js
+++ b/src/webrtc/MediaDevices.js
@@ -383,7 +383,6 @@ export async function getStream(constraintOpt, { replaceStream, fallback = true 
             // NotReadableError - OS can't read
             // AbortError - Other error for browser giving us this
 
-            // Try to revert back to what we had before
             if (replaceStream && !stopTracks) {
                 // We didn't stop the tracks, so let's do that and retry
                 stopStreamTracks(replaceStream, only);

--- a/src/webrtc/MediaDevices.js
+++ b/src/webrtc/MediaDevices.js
@@ -36,7 +36,7 @@ const idFieldsByKind = {
  *
  * @param args
  * @param args.devices - list of available devices
- * @param args.kind - filter by "audioinput" | "videoinput" | "videooutput"
+ * @param args.kind - filter by "audioinput" | "videoinput" | "audiooutput"
  * @returns Array<{[idField]: deviceId}>
  */
 export function buildDeviceList({ busyDeviceIds, devices, kind }) {

--- a/src/webrtc/MediaDevices.js
+++ b/src/webrtc/MediaDevices.js
@@ -36,6 +36,7 @@ const idFieldsByKind = {
  *
  * @param args
  * @param args.devices - list of available devices
+ * @param args.busyDeviceIds - list of busy deviceIds
  * @param args.kind - filter by "audioinput" | "videoinput" | "audiooutput"
  * @returns Array<{[idField]: deviceId}>
  */

--- a/tests/webrtc/mediaConstraints.spec.js
+++ b/tests/webrtc/mediaConstraints.spec.js
@@ -3,10 +3,9 @@ import getConstraints, { getMediaConstraints } from "../../src/webrtc/mediaConst
 // the selectGetConstraintsOptions is testing most permutations of this
 describe("getConstraints", () => {
     const vdev1 = { kind: "videoinput", deviceId: "vdev1" };
+    const adev1 = { kind: "audioinput", deviceId: "adev1" };
 
     it("should not request audio if it is false", () => {
-        const adev1 = { kind: "audioinput", deviceId: "adev1" };
-
         const result = getConstraints({
             devices: [vdev1, adev1],
             videoId: "v",
@@ -15,6 +14,38 @@ describe("getConstraints", () => {
 
         expect(result).toEqual({ video: expect.any(Object) });
     });
+
+    it.each([
+        ["video", null, false, [vdev1]],
+        ["audio", false, null, [adev1]],
+    ])("should request %s if we have a device of right type", (mediaKind, videoId, audioId, devices) => {
+        const result = getConstraints({
+            devices,
+            audioId,
+            videoId,
+        });
+
+        const expected = {};
+        expected[mediaKind] = expect.any(Object);
+        expect(result).toEqual(expected);
+    });
+
+    it.each([
+        ["video", null, false, [adev1]],
+        ["video", false, false, [adev1, vdev1]],
+        ["audio", false, null, [vdev1]],
+        ["audio", false, false, [adev1, vdev1]],
+    ])("should not request %s if device type is missing or if deviceId is false", (_, videoId, audioId, devices) => {
+        const result = getConstraints({
+            devices,
+            audioId,
+            videoId,
+        });
+
+        expect(result).toEqual({});
+    });
+
+    it("should respect type", () => {});
 });
 
 describe("getMediaConstraints", () => {
@@ -34,5 +65,26 @@ describe("getMediaConstraints", () => {
                 expect(result.video.frameRate).toBe(expected);
             }
         );
+    });
+
+    describe("lax", () => {
+        it("lax should delete facingmode on missing deviceId for video", () => {
+            const result = getMediaConstraints({ preferredDeviceIds: {}, lax: true });
+
+            expect(result.video).toEqual(expect.any(Object));
+            expect(result.video.facingMode).toBeUndefined();
+        });
+
+        it("should set audio to true when audioId is missing", () => {
+            const result = getMediaConstraints({ lax: true, preferredDeviceIds: {} });
+
+            expect(result.audio).toBe(true);
+        });
+
+        it("should not set audio to true when audioId is present", () => {
+            const result = getMediaConstraints({ lax: true, preferredDeviceIds: { audioId: "id" } });
+
+            expect(result.audio).toEqual(expect.any(Object));
+        });
     });
 });


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.9.10--canary.92.8342626418.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@1.9.10--canary.92.8342626418.0
  # or 
  yarn add @whereby/jslib-media@1.9.10--canary.92.8342626418.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
