### PR TITLE
Update readme to indicate that the repo has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-jslib-media
-=============
+# THIS REPOSITORY HAS MOVED
 
-This library contains JavaScript modules related to media in Whereby.
-
-## Usage
-
-This should not be used directly, but is a dependency of other Whereby projects.
-
-## Dependencies
-
-**Google Chrome** is used in headless mode to run the unit tests (version 59 or newer).
+The official repository for Whereby/jslib-media is now located at https://github.com/whereby/sdk


### PR DESCRIPTION
Repo has moved, so update readme to point to new location
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.1--canary.101.8448277685.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @whereby/jslib-media@2.0.1--canary.101.8448277685.0
  # or 
  yarn add @whereby/jslib-media@2.0.1--canary.101.8448277685.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
